### PR TITLE
Refactor "pressKeys" as one of many "user intents"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -949,7 +949,7 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
     1. Let |algorithm| be the algorithm associated with user intent |name| in the [=table of extension user intents=].
 4. Otherwise:
     1. Return an [=error=] with [=error code=] [=unknown user intent=].
-5. [=Try=] to evaluate |algorithm| with parameters |command parameters|.
+5. Return the result of evaluating |algorithm| given |command parameters|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -909,9 +909,9 @@ The <dfn>interaction.userIntent</dfn> command simulates pressing a key combinati
   }
 
   InteractionUserIntentParameters = (
-    PressKeysIntentParameters //
+    PressKeysIntentParameters /
     ExtensionIntentParameters
-  }
+  )
 
   PressKeysIntentParameters = {
     "name" => "pressKeys",

--- a/index.bs
+++ b/index.bs
@@ -338,6 +338,10 @@ The following table lists each <dfn>error code</dfn>, its associated JSON `error
     <td>`session not created`
     <td>A new [=session=] could not be created.
   <tr>
+    <td><dfn for="error code">unknown user intent</dfn>
+    <td>`unknown user intent`
+    <td>The remote end does not support a user intent with the provided name.
+  <tr>
     <td><dfn for="error code">cannot simulate keyboard interaction</dfn>
     <td>`cannot simulate keyboard interaction`
     <td>The [=remote end=] cannot simulate keyboard interaction.
@@ -822,12 +826,53 @@ Issue: Do we need a "setting changed" event?
 The Interaction Module {#module-interaction}
 --------------------------------------------
 
+The following <dfn>table of standard user intents</dfn> enumerates the user intents each implementation must support.
+
+<table>
+  <caption>Standard user intents</caption>
+  <tr>
+    <th>Name
+    <th>Algorithm
+  <tr>
+    <td>"`pressKeys`"
+    <td>[=press keys=]
+</table>
+
+A [=remote end=] has a <dfn for="remote end">table of extension user intents</dfn>, which is a mapping of zero or more string names of user intents and algorithms for simulating the named intents. Extension user intents' names must contain a "`:`" (colon) character, denoting an implementation specific namespace.
+
+<div algorithm>
+
+Note: Each string in `KeyCombination` represents a "raw key" consisting of a
+single code point with the same meaning as in <a
+href="https://w3c.github.io/webdriver/#keyboard-actions">WebDriver's keyboard
+actions</a>. For example, `["\uE008", "a"]` means holding the left shift key
+and pressing "a", and then releasing the left shift key. [[WEBDRIVER]]
+
+Issue(34): This algorithm does not yet have a means for indicating a screen-reader specific modifier key (or keys).
+
+Issue(51): This algorithm only supports one specific kind of press/release sequence, and it is not clear if that is sufficient to express all keyboard commands in all implementations.
+
+To <dfn>press keys</dfn> given |command parameters|:
+
+1. [=Try=] to [=check that keyboard interaction can be simulated=].
+2. [=Try=] to [=check that one of the expected applications has focus=].
+3. Let |keys| be the value of the <code>keys</code> field of |command
+    parameters|.
+4. [=list/For each=] |key| of |keys|:
+    1. Run [=implementation-defined=] steps to simulate depressing |key|.
+5. [=list/For each=] |key| of |keys| in reverse [=List=] order:
+    1. Run [=implementation-defined=] steps to simulate releasing |key|.
+6. Let |body| be a new [=map=].
+7. Return [=success=] with data |body|.
+
+</div>
+
 ### Definition ### {#module-interaction-definition}
 
 [=Remote end definition=]:
 
 <xmp class="cddl remote-cddl">
-InteractionCommand = (InteractionPressKeysCommand)
+InteractionCommand = (InteractionUserIntentCommand)
 </xmp>
 
 [=Local end definition=]:
@@ -849,32 +894,38 @@ InteractionCapturedOutputParameters = {
 
 ### Commands ### {#module-interaction-commands}
 
-#### The interaction.pressKeys Command #### {#module-interaction-presskeys}
+#### The interaction.userIntent Command #### {#module-interaction-userintent}
 
-The <dfn>interaction.pressKeys</dfn> command simulates pressing a key combination on a keyboard.
-
-Issue(34): This command does not yet have a means for indicating a screen-reader specific modifier key (or keys).
-
-Issue(51): This algorithm only supports one specific kind of press/release sequence, and it is not clear if that is sufficient to express all keyboard commands in all implementations.
+The <dfn>interaction.userIntent</dfn> command simulates pressing a key combination on a keyboard.
 
 <dl>
   <dt>[=Command Type=]
   <dd>
 
   <pre class="cddl remote-cddl">
-  InteractionPressKeysCommand = {
-    method: "interaction.pressKeys",
-    params: InteractionPressKeysParameters
+  InteractionUserIntentCommand = {
+    method: "interaction.userIntent",
+    params: InteractionUserIntentParameters
   }
 
-  InteractionPressKeysParameters = {
+  InteractionUserIntentParameters = (
+    PressKeysIntentParameters //
+    ExtensionIntentParameters
+  }
+
+  PressKeysIntentParameters = {
+    "name" => "pressKeys",
     "keys" => KeyCombination,
-    Extensible,
   }
 
   KeyCombination = [
     1* text
   ]
+
+  ExtensionIntentParameters = {
+    "name" => text,
+    Extensible,
+  }
   </pre>
 
   <dt>Result Type
@@ -886,24 +937,21 @@ Issue(51): This algorithm only supports one specific kind of press/release seque
 
 </dl>
 
-Note: Each string in `KeyCombination` represents a "raw key" consisting of a
-single code point with the same meaning as in <a
-href="https://w3c.github.io/webdriver/#keyboard-actions">WebDriver's keyboard
-actions</a>. For example, `["\uE008", "a"]` means holding the left shift key
-and pressing "a", and then releasing the left shift key. [[WEBDRIVER]]
+<div algorithm="remote end steps for interaction.userIntent">
 
-The [=remote end steps=] given |session| and |command parameters| are:
+The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
 
-1. [=Try=] to [=check that keyboard interaction can be simulated=].
-2. [=Try=] to [=check that one of the expected applications has focus=].
-3. Let |keys| be the value of the <code>keys</code> field of |command
+1. Let |name| be the value of the <code>name</code> field of |command
     parameters|.
-4. [=list/For each=] |key| of |keys|:
-    1. Run [=implementation-defined=] steps to simulate depressing |key|.
-5. [=list/For each=] |key| of |keys| in reverse [=List=] order:
-    1. Run [=implementation-defined=] steps to simulate releasing |key|.
-6. Let |body| be a new [=map=].
-7. Return [=success=] with data |body|.
+2. If there is an entry in the [=table of standard user intents=] with name |name|:
+    1. Let |algorithm| be the algorithm associated with user intent |name| in the [=table of standard user intents=].
+3. Otherwise, if there is an entry in the [=table of extension user intents=] with name |name|:
+    1. Let |algorithm| be the algorithm associated with user intent |name| in the [=table of extension user intents=].
+4. Otherwise:
+    1. Return an [=error=] with [=error code=] [=unknown user intent=].
+5. [=Try=] to evaluate |algorithm| with parameters |command parameters|.
+
+</div>
 
 ### Events ### {#module-interaction-events}
 

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -74,18 +74,28 @@ SettingsGetSupportedSettingsCommand = {
   params: EmptyParams
 }
 
-InteractionCommand = (InteractionPressKeysCommand)
+InteractionCommand = (InteractionUserIntentCommand)
 
-InteractionPressKeysCommand = {
-  method: "interaction.pressKeys",
-  params: InteractionPressKeysParameters
+InteractionUserIntentCommand = {
+  method: "interaction.userIntent",
+  params: InteractionUserIntentParameters
 }
 
-InteractionPressKeysParameters = {
+InteractionUserIntentParameters = (
+  PressKeysIntentParameters /
+  ExtensionIntentParameters
+)
+
+PressKeysIntentParameters = {
+  "name" => "pressKeys",
   "keys" => KeyCombination,
-  Extensible,
 }
 
 KeyCombination = [
   1* text
 ]
+
+ExtensionIntentParameters = {
+  "name" => text,
+  Extensible,
+}


### PR DESCRIPTION
In conversation with assistive technology vendors, we have learned that automating arbitrary key presses does not necessarily align with the security model of all platforms. Separately, we anticipate introducing means to simulate more specific types of user interaction (e.g. "move to next heading"). Because these may themselves be implemented at the vendor's discretion (and because we wish to allow for vendors to experiment with the development of still more kinds of interaction), the space for simulating interaction may be somewhat fragmented, particularly in the initial deployments of this protocol. We have decided to design a command which accommodates this variability so that the presence/absence of interactions can be communicated consistently (note the "unknown user intent" error) and so that additional interactions can be introduced without the addition of entirely new commands (or entirely new extension commands, as the case may be).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/at-driver/pull/76.html" title="Last updated on Sep 5, 2024, 9:59 PM UTC (71e88bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/at-driver/76/55c2268...71e88bb.html" title="Last updated on Sep 5, 2024, 9:59 PM UTC (71e88bb)">Diff</a>