### PR TITLE
Add missing w3c.json file

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+{
+  "group": "wg/browser-tools-testing",
+  "contacts": ["tidoust"],
+  "repo-type": "rec-track"
+}

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
 {
   "group": "wg/browser-tools-testing",
-  "contacts": ["tidoust"],
+  "contacts": ["tidoust", "jugglinmike"],
   "repo-type": "rec-track"
 }


### PR DESCRIPTION
The file is needed for tools to associate the repository with the group, and in particular to have the repository under the group's list of repositories in https://www.w3.org/groups/wg/browser-tools-testing/tools/

See documentation at: https://w3c.github.io/w3c.json.html