### PR TITLE
Re-order CDDL definitions so that Command / Message are first

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -121,10 +121,6 @@ This section gives the initial contents of the remote end definition and local e
 [=Remote end definition=]
 
 <xmp class="cddl remote-cddl">
-Extensible = {
-  *text => any
-}
-
 Command = {
   id: uint,
   CommandData,
@@ -143,10 +139,6 @@ EmptyParams = { Extensible }
 [=Local end definition=]:
 
 <xmp class="cddl local-cddl">
-Extensible = {
-  *text => any
-}
-
 Message = (
   CommandResponse //
   ErrorResponse //
@@ -183,6 +175,14 @@ Event = {
 EventData = (
   InteractionEvent
 )
+</xmp>
+
+[=Remote end definition=] and [=local end definition=]:
+
+<xmp class="cddl remote-cddl local-cddl">
+Extensible = {
+  *text => any
+}
 </xmp>
 
 Capabilities {#protocol-capabilities}

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -1,7 +1,3 @@
-Extensible = {
-  *text => any
-}
-
 Message = (
   CommandResponse //
   ErrorResponse //
@@ -38,6 +34,10 @@ Event = {
 EventData = (
   InteractionEvent
 )
+
+Extensible = {
+  *text => any
+}
 
 SessionResult = (SessionNewResult)
 

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -1,7 +1,3 @@
-Extensible = {
-  *text => any
-}
-
 Command = {
   id: uint,
   CommandData,
@@ -15,6 +11,10 @@ CommandData = (
 )
 
 EmptyParams = { Extensible }
+
+Extensible = {
+  *text => any
+}
 
 SessionCommand = (SessionNewCommand)
 


### PR DESCRIPTION
The first rule in a CDDL document defines the entry point to validate a CBOR data item. The CDDL of each module started with `Extensible`, which essentially made any CBOR data item valid.

This update makes `Command` and `Message` the first CDDL rules in each module (as done in WebDriver BiDi), and defines `Extensible` is a single block common to both the remote end and local end definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/at-driver/pull/83.html" title="Last updated on Dec 18, 2024, 2:55 AM UTC (de116f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/at-driver/83/fdb685b...tidoust:de116f7.html" title="Last updated on Dec 18, 2024, 2:55 AM UTC (de116f7)">Diff</a>