### PR TITLE
Use `<code>` for references to a CDDL type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -720,9 +720,9 @@ Issue: Require implementations to report failures in settings modification opera
   </dd>
   <dt>[=Result Type=]</dt>
   <dd>
-    <xmp class="cddl">
+    <code>
     EmptyResult
-    </xmp>
+    </code>
   </dd>
 </dl>
 
@@ -765,9 +765,9 @@ The <dfn>settings.getSettings command</dfn> returns a list of the requested sett
   </dd>
   <dt>[=Result Type=]</dt>
   <dd>
-    <xmp class="cddl">
+    <code>
     SettingsGetSettingsResult
-    </xmp>
+    </code>
   </dd>
 </dl>
 
@@ -796,9 +796,9 @@ The <dfn>settings.getSupportedSettings command</dfn> returns a list of all setti
   </dd>
   <dt>[=Result Type=]</dt>
   <dd>
-    <xmp class="cddl">
+    <code>
     SettingsGetSettingsResult
-    </xmp>
+    </code>
   </dd>
 </dl>
 
@@ -882,9 +882,9 @@ Issue(51): This algorithm only supports one specific kind of press/release seque
   <dt>Result Type
   <dd>
 
-  <pre class="cddl">
+  <code>
   EmptyResult
-  </pre>
+  </code>
 
 </dl>
 


### PR DESCRIPTION
See https://github.com/w3c/webdriver-bidi/pull/831 for background.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/at-driver/pull/85.html" title="Last updated on Dec 19, 2024, 8:33 PM UTC (b519b6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/at-driver/85/7cb6e57...tidoust:b519b6c.html" title="Last updated on Dec 19, 2024, 8:33 PM UTC (b519b6c)">Diff</a>